### PR TITLE
Updated Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,18 +11,12 @@
 ^inst/python$
 
 ^R/add_filter\.R$
-^R/calc_cv\.R$
-^R/calculate_log2FC\.R$
 ^R/do_anova_2w\.R$
 ^R/filter_groupwise\.R$
-^R/impute_data\.R$
 ^R/perform_ANOVA\.R$
-^R/transform_data\.R$
-^R/two_way_anova\.R$
 
 ^R/draw_FC_network\.R$
 ^R/plot_2w_anvova\.R$
-^R/plot_log2FC\.R$
 ^R/plot_network\.R$
 
 ^tests$


### PR DESCRIPTION
Changed .Rbuildignore so you can use install.github() from devtools, to use the newest version of MetAlyzer.